### PR TITLE
Fix broken build in generator

### DIFF
--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(generator
     src/main.cpp
 )
 target_compile_features(generator PRIVATE cxx_std_20)
+target_compile_options(generator PRIVATE "-fcoroutines")
 
 target_link_libraries(generator PRIVATE ce::utils Boost::headers)
 


### PR DESCRIPTION
Add `-fcoroutines` compiler option for `generator` target.

I guess that it works without this flag on your system, but this fix might be helpful for the majority of students. If there is a replacement for `target_compile_options` in ntc, I can use it (I guess that `_ntc_try_append_cxx_flag` is not applicable here because we need to specify a flag for a particular target).